### PR TITLE
ステップ7-3: タスクを削除できるようにしましょう

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -5,3 +5,6 @@
 .link_edit {
     color: blue;
 }
+.link_delete {
+    color: red;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,7 +19,6 @@ class TasksController < ApplicationController
     else
       render "new"
     end
-    
   end
 
   def edit
@@ -34,7 +33,12 @@ class TasksController < ApplicationController
     else
       render "edit"
     end
-    
+  end
+  
+  def destroy
+    Task.find(params[:id]).destroy
+    flash[:success] = "タスクの削除が完了しました！"
+    redirect_to tasks_path
   end
   
   

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,7 @@ class TasksController < ApplicationController
     @task = Task.new(task_params)
     if @task.save
       redirect_to tasks_path
-      flash[:success] = "タスクの作成が完了しました！"
+      flash[:success] = "タスクを作成しました！"
     else
       render "new"
     end
@@ -29,7 +29,7 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
     if @task.update_attributes(task_params)
       redirect_to @task
-      flash[:success] = "タスクの編集が完了しました！"
+      flash[:success] = "タスクを編集しました！"
     else
       render "edit"
     end
@@ -37,7 +37,7 @@ class TasksController < ApplicationController
   
   def destroy
     Task.find(params[:id]).destroy
-    flash[:success] = "タスクの削除が完了しました！"
+    flash[:success] = "タスクを削除しました！"
     redirect_to tasks_path
   end
   

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,3 +2,4 @@
 <h3><%= @task.name %></h3>
 <p><%= @task.content %></p>
 <%= link_to "編集", edit_task_path(@task), class: "link_edit" %>
+<%= link_to "削除", @task, method: :delete, class: "link_delete", data: {confirm: "本当に削除しますか？"} %>


### PR DESCRIPTION
# カリキュラム
[ステップ7-3: タスクを削除できるようにしましょう](https://github.com/KazukiHayase/task-management-app/blob/master/doc/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%977-2-%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AE%E4%BD%9C%E6%88%90%E7%94%BB%E9%9D%A2%E7%B7%A8%E9%9B%86%E7%94%BB%E9%9D%A2%E3%82%92%E4%BD%9C%E6%88%90%E3%81%97%E3%81%BE%E3%81%97%E3%82%87%E3%81%86)

# 処理概要
Taskコントローラーに`destroy`メソッドを追加しタスクを削除できるようにしました。

# 要件・仕様
作成したタスクを削除できるようにする

# 動作確認
画面上でタスクが削除できるのを確認
![タイトルなし](https://user-images.githubusercontent.com/74339461/99371785-b51a3880-2902-11eb-8e4c-6a2aba93108b.gif)

