### PR TITLE
ステップ16: 終了期限を追加しよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
+  gem 'database_cleaner-active_record'
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'rails-i18n'
 
+gem "jquery-rails"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -213,6 +217,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)
   puma (~> 3.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    database_cleaner (1.8.5)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     execjs (2.7.0)
@@ -215,6 +219,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
+  database_cleaner-active_record
   factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,5 @@
 //= require rails-ujs
 //= require activestorage
 //= require_tree .
+//= require jquery
+//= require jquery_ujs

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,6 @@
 //
 //= require rails-ujs
 //= require activestorage
-//= require_tree .
 //= require jquery
 //= require jquery_ujs
+//= require_tree .

--- a/app/assets/javascripts/task.js
+++ b/app/assets/javascripts/task.js
@@ -1,0 +1,9 @@
+$(document).ready(function(){
+  // セレクトボックスが変更されたら送信
+  $("#sort_tasks_select").change(function(){
+    const value = $("#sort_tasks_select").val();
+    if (value) {
+      $('#sort_tasks_form').submit();
+    }
+  });
+});

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -8,3 +8,47 @@
 .link_delete {
     color: red;
 }
+.task_list {
+    text-align: center;
+    border: 1px solid #9e9e9e;
+    border-bottom: none;
+
+    .element_title {
+        display: flex;
+        padding: 10px 0;
+        color: #55c500;
+        font-weight: bold;
+        border-bottom: 1px solid #888888;
+        box-shadow: 0 1px 2px grey;
+    }
+    .task_item {
+        display: flex;
+        padding: 10px 0;
+        border-bottom: 1px solid #b9b9b9;
+
+        &:nth-child(2n+1) {
+            background-color: #ececec;
+        }
+    }
+    .name {
+        width: 100px;
+        font-weight: bold;
+    }
+    .content {
+        width: 200px;
+    }
+    .deadline {
+        width: 150px;
+    }
+}
+.task_show {
+    .task_element_list {
+        li {
+            margin-bottom: 8px;
+            font-size: 20px;
+            h4 {
+                margin: 0 0 5px 0;
+            }
+        }
+    }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
     http_basic_authenticate_with name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_AUTH_PASSWORD'] if Rails.env == 'production'
+    include TasksHelper
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -44,7 +44,6 @@ class TasksController < ApplicationController
   def sort
     sort_number = params[:sort_number].to_i
     @tasks = sort_tasks(sort_number)
-    puts @tasks
     respond_to do |format|
       format.html { redirect_to tasks_path }
       format.js

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -40,6 +40,17 @@ class TasksController < ApplicationController
     flash[:success] = "タスクを削除しました！"
     redirect_to tasks_path
   end
+
+  def sort
+    sort_number = params[:sort_number].to_i
+    @tasks = sort_tasks(sort_number)
+    puts @tasks
+    respond_to do |format|
+      format.html { redirect_to tasks_path }
+      format.js
+    end
+  end
+  
   
   
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -47,7 +47,7 @@ class TasksController < ApplicationController
   private
 
     def task_params
-      params.require(:task).permit(:name, :content)
+      params.require(:task).permit(:name, :content, :deadline)
     end
     
   

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,10 @@
 module TasksHelper
+    def sort_tasks(sort_number)
+        case sort_number
+        when 1
+            Task.all.order(deadline: :ASC)
+        when 2
+            Task.all.order(deadline: :DESC)
+        end
+    end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,13 @@
 class Task < ApplicationRecord
     validates :name, presence: true, length: {maximum: 50}
     validates :content, presence: :true, length: {maximum:200}
+    validate  :date_not_before_today
+
+    private
+    
+    def date_not_before_today
+        if deadline.present? && deadline < Date.today
+            errors.add(:deadline, "は今日以降を選択してください")
+        end
+    end
 end

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: @task, local: true do |f| %>
+    <%= render 'layouts/error_messages', model: f.object %>
+    <div>
+        <%= f.label :name %>
+        <br>
+        <%= f.text_field :name %>
+    </div>
+    <div>
+        <%= f.label :content %>
+        <br>
+        <%= f.text_area :content %>
+    </div>
+    <div>
+        <%= f.label :deadline %>
+        <br>
+        <%= f.date_field :deadline %>
+    </div>
+    <%= f.submit submit_text %>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,7 @@
+<% tasks.each do |task| %>
+    <li class="task_item">
+        <div class="name"><%= link_to task.name, task_path(task) %></div>
+        <div class="content"><%= task.content %></div>
+        <div class="deadline"><%= task.deadline %></div>
+    </li>
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,12 +1,2 @@
 <h1>タスク編集画面</h1>
-<%= form_with model: @task, local: true do |f| %>
-    <div>
-        <%= f.label :name %>
-        <%= f.text_field :name %>
-    </div>
-    <div>
-        <%= f.label :content %>
-        <%= f.text_area :content %>
-    </div>
-    <%= f.submit "保存" %>
-<% end %>
+<%= render 'shared/form', submit_text: "保存" %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,8 @@
 <h1>タスク一覧画面</h1>
+<%= form_with url: sort_tasks_path, id: "sort_tasks_form" do |f| %>
+    <%= f.select :sort_number, [["締め切り日が近い順", 1],["締め切り日が遠い順", 2]] %>
+    <%= f.submit "ソート" %>
+<% end %>
 <ul class="task_list">
     <li class="element_title">
         <div class="name">タスク名</div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,15 +1,11 @@
 <h1>タスク一覧画面</h1>
-    <ul class="task_list">
-        <li class="element_title">
-            <div class="name">タスク名</div>
-            <div class="content">内容</div>
-            <div class="deadline">締め切り日</div>
-        </li>
-        <% @tasks.each do |task| %>
-            <li class="task_item">
-                <div class="name"><%= link_to task.name, task_path(task) %></div>
-                <div class="content"><%= task.content %></div>
-                <div class="deadline"><%= task.deadline %></div>
-            </li>
-        <% end %>
-    </ul>
+<ul class="task_list">
+    <li class="element_title">
+        <div class="name">タスク名</div>
+        <div class="content">内容</div>
+        <div class="deadline">締め切り日</div>
+    </li>
+    <div id="tasks">
+        <%= render "task", tasks: @tasks %>
+    </div>
+</ul>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,9 @@
 <h1>タスク一覧画面</h1>
 <%= form_with url: sort_tasks_path, id: "sort_tasks_form" do |f| %>
-    <%= f.select :sort_number, [["締め切り日が近い順", 1],["締め切り日が遠い順", 2]] %>
-    <%= f.submit "ソート" %>
+    <%= f.select :sort_number, [["締め切り日が近い順", 1],
+                                ["締め切り日が遠い順", 2] ], 
+                                {include_blank: "並び替え"}, 
+                                {id: "sort_tasks_select"} %>
 <% end %>
 <ul class="task_list">
     <li class="element_title">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,11 +1,15 @@
-<h1>タスク一覧</h1>
-<ul class="tasks">
-    <% @tasks.each do |task| %>
-        <li class="task">
-        <%= link_to task_path(task) do %>
-            <h3><%= task.name %></h3>
-            <p><%= task.content %></p>
-        <% end %>
+<h1>タスク一覧画面</h1>
+    <ul class="task_list">
+        <li class="element_title">
+            <div class="name">タスク名</div>
+            <div class="content">内容</div>
+            <div class="deadline">締め切り日</div>
         </li>
-    <% end %>
-</ul>
+        <% @tasks.each do |task| %>
+            <li class="task_item">
+                <div class="name"><%= link_to task.name, task_path(task) %></div>
+                <div class="content"><%= task.content %></div>
+                <div class="deadline"><%= task.deadline %></div>
+            </li>
+        <% end %>
+    </ul>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,15 +1,2 @@
-<h1>タスクの作成</h1>
-<%= form_with model: @task, local: true do |f| %>
-    <%= render 'layouts/error_messages', model: f.object %>
-    <div>
-        <%= f.label :name %>
-        <br>
-        <%= f.text_field :name %>
-    </div>
-    <div>
-        <%= f.label :content %>
-        <br>
-        <%= f.text_area :content %>
-    </div>
-    <%= f.submit "作成" %>
-<% end %>
+<h1>タスク作成画面</h1>
+<%= render 'shared/form', submit_text: "作成" %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,19 @@
-<h1>タスク詳細</h1>
-<h3><%= @task.name %></h3>
-<p><%= @task.content %></p>
-<%= link_to "編集", edit_task_path(@task), class: "link_edit" %>
-<%= link_to "削除", @task, method: :delete, class: "link_delete", data: {confirm: "本当に削除しますか？"} %>
+<div class="task_show">
+    <h1>タスク詳細画面</h1>
+    <ul class="task_element_list">
+        <li>
+            <h4>タスク名</h4>
+            <div><%= @task.name %></div>
+        </li>
+        <li>
+            <h4>内容</h4>
+            <div><%= @task.content %></div>
+        </li>
+        <li>
+            <h4>締め切り日</h4>
+            <div><%= @task.deadline %></div>
+        </li>
+    </ul>
+    <%= link_to "編集", edit_task_path(@task), class: "link_edit" %>
+    <%= link_to "削除", @task, method: :delete, class: "link_delete", data: {confirm: "本当に削除しますか？"} %>
+</div>

--- a/app/views/tasks/sort.js.erb
+++ b/app/views/tasks/sort.js.erb
@@ -1,0 +1,1 @@
+$("#tasks").html("<%= escape_javascript(render('tasks/task', tasks: @tasks)) %>");

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -6,3 +6,4 @@ ja:
       task:
         name: タスク名
         content: 内容
+        deadline: 締め切り日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  get 'tasks/index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :tasks
+  resources :tasks 
+  post "tasks/sort", to: "tasks#sort", as: "sort_tasks"
 end

--- a/db/migrate/20201125070024_add_deadline_to_tasks.rb
+++ b/db/migrate/20201125070024_add_deadline_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDeadlineToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_025414) do
+ActiveRecord::Schema.define(version: 2020_11_25_070024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_11_25_025414) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "deadline"
   end
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     links:
       - db
       - node
+      - selenium_chrome
     working_dir: /var/src/app
     command: /bin/sh -c "rm -f /var/src/app/tmp/pids/server.pid;bundle exec rails s -b 0.0.0.0"
     cap_add:
@@ -53,4 +54,6 @@ services:
     image: selenium/standalone-chrome-debug
     logging:
       driver: none
+    ports:
+      - 4444:4444
     container_name: selenium_chrome

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :task do
-    sequence(:name) { |n| "task#{n}" }
+    sequence(:name) { |n| "タスク#{n}" }
     content  { "これはタスクの説明です" }
+    sequence(:deadline, Date.today)
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -29,5 +29,10 @@ RSpec.describe Task, type: :model do
       task.content = "a" * 201
       is_expected.to be_invalid
     end
+
+    it "締め切り日が今日よりも前の時" do
+      task.deadline -= 10
+      is_expected.to be_invalid
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 
 # capybaraの設定
 Capybara.register_driver :remote_chrome do |app|
-  url = "http://chrome:4444/wd/hub"
+  url = "http://selenium_chrome:4444/wd/hub"
   caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
     "goog:chromeOptions" => {
       "args" => [

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -1,0 +1,5 @@
+def sort(text)
+    select(text, from: "sort_tasks_select")
+    page.evaluate_script("$('#sorttasks_select').trigger('change')")
+    sleep 1
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,14 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe "Tasks", type: :system do
-    let!(:tasks) { create_list(:task, 3) } 
+RSpec.describe "Tasks", js: true, type: :system do
+    before do
+        @tasks = create_list(:task, 3)
+    end
+
+    before(:each) do
+        visit tasks_path
+    end
+    
+    subject { first(".task_item .name") }
     
     it "タスクが作成日時の降順で並んでいること" do
-        visit tasks_path
-        tasks_view = all(".task")
+        is_expected.to have_content @tasks[2].name
+    end
 
-        expect(tasks_view[0].find("h3").text).to eq tasks[2].name
-        expect(tasks_view[1].find("h3").text).to eq tasks[1].name
-        expect(tasks_view[2].find("h3").text).to eq tasks[0].name
+    it "タスクが締め切り日の昇順で並んでいること" do
+        sort("締め切り日が近い順")
+        is_expected.to have_content @tasks[0].name
+    end
+
+    it "タスクが締め切り日の降順で並んでいること" do
+        sort("締め切り日が遠い順")
+        is_expected.to have_content @tasks[2].name
     end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,26 +2,28 @@ require 'rails_helper'
 
 RSpec.describe "Tasks", js: true, type: :system do
     before do
-        @tasks = create_list(:task, 3)
+        tasks
     end
 
     before(:each) do
         visit tasks_path
     end
-    
+
+    let(:tasks) { create_list(:task, 3) } 
+
     subject { first(".task_item .name") }
     
     it "タスクが作成日時の降順で並んでいること" do
-        is_expected.to have_content @tasks[2].name
+        is_expected.to have_content tasks[2].name
     end
 
     it "タスクが締め切り日の昇順で並んでいること" do
         sort("締め切り日が近い順")
-        is_expected.to have_content @tasks[0].name
+        is_expected.to have_content tasks[0].name
     end
 
     it "タスクが締め切り日の降順で並んでいること" do
         sort("締め切り日が遠い順")
-        is_expected.to have_content @tasks[2].name
+        is_expected.to have_content tasks[2].name
     end
 end


### PR DESCRIPTION
# カリキュラム
[ステップ16: 終了期限を追加しよう](https://github.com/KazukiHayase/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9716-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)

# 処理概要
`Task`に対してdeadlineカラムとバリデーションを追加しました。
taskscontrollerにsortメソッドを追加して締め切り日でソートできるようにしました。
締め切り日のソート に対するテストを作成しました。

# 要件・仕様
タスクに対して、終了期限を登録できるようにする。
一覧画面で、終了期限でソートできるようにする。
specを拡充する。

# 動作確認
テストが通ることを確認
<img width="754" alt="スクリーンショット 2020-12-01 12 29 02" src="https://user-images.githubusercontent.com/52494270/100694445-768c7f80-33d2-11eb-8ed8-8f4bb78eed70.png">

ブラウザ上で締め切り日でソートされることを確認
![タイトルなし](https://user-images.githubusercontent.com/52494270/100694472-873cf580-33d2-11eb-8ca3-196895f46dc0.gif)
