### PR TITLE
ステップ18: 優先順位を設定しよう（※類似した実装経験のある人は省略可）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'enum_help'
 gem 'rubocop', require:false
 gem 'rubocop-rails', require:false
 
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -62,7 +61,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'database_cleaner-active_record'
 end
-
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -33,12 +33,12 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
-
 gem 'rails-i18n'
-
 gem "jquery-rails"
-
 gem 'enum_help' 
+gem 'rubocop', require:false
+gem 'rubocop-rails', require:false
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    ast (2.4.1)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -134,6 +135,9 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    parallel (1.20.1)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
     pg (1.1.4)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -170,11 +174,13 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.8.2)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -196,6 +202,22 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
+    rubocop (1.4.2)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 1.1.1)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.3.0)
+      parser (>= 2.7.1.5)
+    rubocop-rails (2.8.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.87.0)
+    ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -231,6 +253,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.7.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -262,6 +285,8 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-i18n
   rspec-rails
+  rubocop
+  rubocop-rails
   sass-rails (~> 5.0.7)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -46,6 +46,9 @@
     .status {
         width: 100px;
     }
+    .priority {
+        width: 100px;
+    }
 }
 .task_show {
     .task_element_list {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,6 @@
 class TasksController < ApplicationController
   def index
-    @tasks = Task.all.order(created_at: "DESC")
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -42,8 +42,11 @@ class TasksController < ApplicationController
   end
 
   def sort
-    sort_number = params[:sort_number].to_i
-    @tasks = sort_tasks(sort_number)
+    sort_data = params[:sort_data].split("_")
+    column = sort_column(sort_data[0])
+    direction = sort_direction(sort_data[1])
+    @tasks = Task.sorted_by(column, direction)
+
     respond_to do |format|
       format.html { redirect_to tasks_path }
       format.js

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -72,5 +72,11 @@ class TasksController < ApplicationController
       params.require(:task).permit(:name, :content, :deadline, :status, :priority)
     end
 
-  
+    def sort_column(column)
+        Task.column_names.include?(column) ? column : "created_at"
+    end
+
+    def sort_direction(direction)
+        %w[asc desc].include?(direction) ? direction : "desc"
+    end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -69,7 +69,7 @@ class TasksController < ApplicationController
   private
 
     def task_params
-      params.require(:task).permit(:name, :content, :deadline, :status)
+      params.require(:task).permit(:name, :content, :deadline, :status, :priority)
     end
 
   

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,12 @@
 class TasksController < ApplicationController
+  before_action :get_task, only: [:show, :edit, :update]
+
   def index
     @tasks = Task.all.order(created_at: :desc)
   end
 
   def show
-    @task = Task.find(params[:id])
+    
   end
   
   def new
@@ -22,11 +24,10 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
+
   end
 
   def update
-    @task = Task.find(params[:id])
     if @task.update_attributes(task_params)
       flash[:success] = "タスクを編集しました！"
       redirect_to @task
@@ -79,4 +80,9 @@ class TasksController < ApplicationController
     def sort_direction(direction)
         %w[asc desc].include?(direction) ? direction : "desc"
     end
+
+    def get_task
+      @task = Task.find(params[:id])
+    end
+    
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,12 +1,11 @@
 class TasksController < ApplicationController
-  before_action :get_task, only: [:show, :edit, :update]
+  before_action :get_task, only: [:show, :edit, :update, :destory]
 
   def index
     @tasks = Task.all.order(created_at: :desc)
   end
 
   def show
-    
   end
   
   def new
@@ -24,7 +23,6 @@ class TasksController < ApplicationController
   end
 
   def edit
-
   end
 
   def update
@@ -37,7 +35,7 @@ class TasksController < ApplicationController
   end
   
   def destroy
-    Task.find(params[:id]).destroy
+    @task.destroy
     flash[:success] = "タスクを削除しました！"
     redirect_to tasks_path
   end
@@ -64,9 +62,6 @@ class TasksController < ApplicationController
     end
   end
   
-  
-
-
   private
 
     def task_params
@@ -84,5 +79,4 @@ class TasksController < ApplicationController
     def get_task
       @task = Task.find(params[:id])
     end
-    
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,10 +1,9 @@
 module TasksHelper
-    def sort_tasks(sort_number)
-        case sort_number
-        when 1
-            Task.all.order(deadline: :ASC)
-        when 2
-            Task.all.order(deadline: :DESC)
-        end
+    def sort_column(column)
+        Task.column_names.include?(column) ? column : "created_at"
+    end
+
+    def sort_direction(direction)
+        %w[asc desc].include?(direction) ? direction : "desc"
     end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,9 +1,3 @@
 module TasksHelper
-    def sort_column(column)
-        Task.column_names.include?(column) ? column : "created_at"
-    end
-
-    def sort_direction(direction)
-        %w[asc desc].include?(direction) ? direction : "desc"
-    end
+    
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
     validates :name, presence: true, length: {maximum: 50}
-    validates :content, presence: :true, length: {maximum:200}
+    validates :content, presence: true, length: {maximum:200}
     validate  :date_not_before_today
 
     enum status: {"not_started": 1, "doing": 2, "done": 3}
@@ -11,6 +11,7 @@ class Task < ApplicationRecord
     }
     scope :name_like, -> (keyword) { where("name LIKE ?", "%#{keyword}%") if keyword.present?}
     scope :status_is, -> (status) { where(status: status) if status.present?}
+    scope :sorted_by, -> (column, direction) { order("#{column} #{direction}")}
 
     private
     

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,6 +4,7 @@ class Task < ApplicationRecord
     validate  :date_not_before_today
 
     enum status: {"not_started": 1, "doing": 2, "done": 3}
+    enum priority: {"low": 1, "middle": 2, "high": 3}
 
     scope :search, lambda { |search_params|
         name_like(search_params[:keyword])

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -20,5 +20,10 @@
         <br>
         <%= f.select :status, Task.statuses_i18n.invert %>
     </div>
+    <div>
+        <%= f.label :priority %>
+        <br>
+        <%= f.select :priority, Task.priorities_i18n.invert %>
+    </div>
     <%= f.submit submit_text %>
 <% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -4,5 +4,6 @@
         <div class="content"><%= task.content %></div>
         <div class="deadline"><%= task.deadline %></div>
         <div class="status"><%= task.status_i18n %></div>
+        <div class="priority"><%= task.priority_i18n %></div>
     </li>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,7 +17,9 @@
 <% end %>
 <%= form_with url: sort_tasks_path, id: "sort_tasks_form" do |f| %>
     <%= f.select :sort_data, [["締め切り日が近い順", "deadline_asc"],
-                                ["締め切り日が遠い順", "deadline_desc"] ], 
+                                ["締め切り日が遠い順", "deadline_desc"], 
+                                ["優先順位が低い順", "priority_asc"], 
+                                ["優先順位が高い順", "priority_desc"]], 
                                 {include_blank: "並び替え"}, 
                                 {id: "sort_tasks_select"} %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,8 +16,8 @@
     <%= f.submit "検索" %>
 <% end %>
 <%= form_with url: sort_tasks_path, id: "sort_tasks_form" do |f| %>
-    <%= f.select :sort_number, [["締め切り日が近い順", 1],
-                                ["締め切り日が遠い順", 2] ], 
+    <%= f.select :sort_data, [["締め切り日が近い順", "deadline_asc"],
+                                ["締め切り日が遠い順", "deadline_desc"] ], 
                                 {include_blank: "並び替え"}, 
                                 {id: "sort_tasks_select"} %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -27,6 +27,7 @@
         <div class="content">内容</div>
         <div class="deadline">締め切り日</div>
         <div class="status">ステータス</div>
+        <div class="priority">優先順位</div>
     </li>
     <div id="tasks">
         <%= render "task", tasks: @tasks %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -17,6 +17,10 @@
             <h4>ステータス</h4>
             <div><%= @task.status_i18n %></div>
         </li>
+        <li>
+            <h4>優先順位</h4>
+            <div><%= @task.priority_i18n %></div>
+        </li>
     </ul>
     <%= link_to "編集", edit_task_path(@task), class: "link_edit" %>
     <%= link_to "削除", @task, method: :delete, class: "link_delete", data: {confirm: "本当に削除しますか？"} %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,9 +8,14 @@ ja:
         content: 内容
         deadline: 締め切り日
         status: ステータス
+        priority: 優先順位
   enums:
     task:
       status:
         not_started: "未着手"
         doing: "着手中"
         done: "完了"
+      priority:
+        low: "低"
+        middle: "中"
+        high: "高"

--- a/db/migrate/20201202092829_add_priority_to_tasks.rb
+++ b/db/migrate/20201202092829_add_priority_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPriorityToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :priority, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_093119) do
+ActiveRecord::Schema.define(version: 2020_12_02_092829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_093119) do
     t.datetime "updated_at", null: false
     t.date "deadline"
     t.integer "status"
+    t.integer "priority"
     t.index ["name"], name: "index_tasks_on_name"
     t.index ["status"], name: "index_tasks_on_status"
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,14 +4,22 @@ FactoryBot.define do
     content  { "これはタスクの説明です" }
     sequence(:deadline, Date.today)
     status { :not_started }
-    priority { :low }
+    priority { :middle }
 
     trait :doing do
-      status{ :doing }
+      status { :doing }
     end
 
     trait :done do
-      status{ :done }
+      status { :done }
+    end
+
+    trait :low do
+      priority { :low }
+    end
+
+    trait :high do
+      priority { :high }
     end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     content  { "これはタスクの説明です" }
     sequence(:deadline, Date.today)
     status { "not_started" }
+    priority { "low" }
 
     trait :doing do
       status{ "doing" }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,15 +3,15 @@ FactoryBot.define do
     sequence(:name) { |n| "タスク#{n}" }
     content  { "これはタスクの説明です" }
     sequence(:deadline, Date.today)
-    status { "not_started" }
-    priority { "low" }
+    status { :not_started }
+    priority { :low }
 
     trait :doing do
-      status{ "doing" }
+      status{ :doing }
     end
 
     trait :done do
-      status{ "done" }
+      status{ :done }
     end
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Tasks", js: true, type: :system do
     let(:tasks) { create_list(:task, 3) } 
     let(:task_doing) { create(:task, :doing) } 
     let(:task_done) { create(:task, :done) } 
+    let(:task_low) { create(:task, :low) } 
+    let(:task_high) { create(:task, :high) } 
     
 
     describe "ソート機能" do
@@ -18,14 +20,30 @@ RSpec.describe "Tasks", js: true, type: :system do
             is_expected.to have_content tasks[2].name
         end
 
-        it "タスクが締め切り日の昇順で並んでいること" do
-            sort("締め切り日が近い順")
-            is_expected.to have_content tasks[0].name
+        context "締め切り日の昇順でソートした時" do
+            before {sort("締め切り日が近い順")}
+            it {is_expected.to have_content tasks[0].name}
         end
 
-        it "タスクが締め切り日の降順で並んでいること" do
-            sort("締め切り日が遠い順")
-            is_expected.to have_content tasks[2].name
+        context "締め切り日の降順でソートした時" do
+            before {sort("締め切り日が遠い順")}
+            it {is_expected.to have_content tasks[2].name}
+        end
+
+        context "優先順位の昇順でソートした時" do
+            before do
+                task_low
+                sort("優先順位が低い順")
+            end 
+            it {is_expected.to have_content task_low.name}
+        end
+
+        context "優先順位の降順でソートした時" do
+            before do
+                task_high
+                sort("優先順位が高い順")
+            end
+            it {is_expected.to have_content task_high.name}
         end
     end
 
@@ -39,20 +57,29 @@ RSpec.describe "Tasks", js: true, type: :system do
 
         subject { page } 
 
-        it "ステータスで検索" do
-            select("着手中", from: "status")
-            is_expected.to  have_content task_doing.name
+        context "ステータスで検索した時" do
+            before do 
+                select("着手中", from: "status")
+                click_button "検索"
+            end
+            it {is_expected.to  have_content task_doing.name}
         end
 
-        it "タイトルで検索" do
-            fill_in("キーワード", with: "タスク")
-            is_expected.to  have_content tasks[0].name
+        context "タイトルで検索した時" do
+            before do
+                fill_in("キーワード", with: "タスク")
+                click_button "検索"
+            end
+            it {is_expected.to  have_content tasks[0].name}
         end
 
-        it "ステータスとタイトルで検索" do
-            select("完了", from: "status")
-            fill_in("キーワード", with: "タスク")
-            is_expected.to  have_content task_done.name
+        context "ステータスとタイトルで検索した時" do
+            before do
+                select("完了", from: "status")
+                fill_in("キーワード", with: "タスク")
+                click_button "検索"
+            end
+            it {is_expected.to  have_content task_done.name}
         end
     end
 end


### PR DESCRIPTION
# カリキュラム
[ステップ18: 優先順位を設定しよう（※類似した実装経験のある人は省略可）](https://github.com/KazukiHayase/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E5%84%AA%E5%85%88%E9%A0%86%E4%BD%8D%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86%E9%A1%9E%E4%BC%BC%E3%81%97%E3%81%9F%E5%AE%9F%E8%A3%85%E7%B5%8C%E9%A8%93%E3%81%AE%E3%81%82%E3%82%8B%E4%BA%BA%E3%81%AF%E7%9C%81%E7%95%A5%E5%8F%AF)

# 処理概要
taskテーブルにpriorityカラムを追加しました
タスクモデルに優先順位を追加してソート機能を追加しました
ソートに関するsystemspecを追加しました

# 要件・仕様
タスクに対し優先順位（高中低）を登録できるようにする
優先順位でソートできるようにする
system specを拡充する

# 動作確認
テストがパスすることを確認
ブラウザ上でソートされることを確認
![タイトルなし](https://user-images.githubusercontent.com/74339461/101423732-1602c280-393d-11eb-94f9-fc17b13d9d36.gif)
