### PR TITLE
ステップ21: 複数人で利用できるようにしよう（ユーザの導入）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     ast (2.4.1)
     autoprefixer-rails (10.0.3.0)
       execjs
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -282,6 +283,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
   byebug

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+    belongs_to :user
     validates :name, presence: true, length: {maximum: 50}
     validates :content, presence: true, length: {maximum:200}
     validate  :date_not_before_today

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+    has_many :tasks, dependent: :destroy
     validates :name, presence: true, length: {maximum: 50}
     VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
     validates :email, presence: true, length: {maximum: 50}, format: {with: VALID_EMAIL_REGEX}, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,7 @@
 class User < ApplicationRecord
+    validates :name, presence: true, length: {maximum: 50}
+    VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    validates :email, presence: true, length: {maximum: 50}, format: {with: VALID_EMAIL_REGEX}, uniqueness: true
+    has_secure_password validations: true
+    validates :password, length: {minimum: 6}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,13 @@
 class User < ApplicationRecord
-    has_many :tasks, dependent: :destroy
-    validates :name, presence: true, length: {maximum: 50}
+    # バリデーション
     VALID_EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    validates :name, presence: true, length: {maximum: 50}
     validates :email, presence: true, length: {maximum: 50}, format: {with: VALID_EMAIL_REGEX}, uniqueness: true
-    has_secure_password validations: true
     validates :password, length: {minimum: 6}
+    
+    # アソシエーション
+    has_many :tasks, dependent: :destroy
+
+    # その他
+    has_secure_password validations: true
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,8 +1,14 @@
 ja:
   activerecord:
     models:
+      user: ユーザー
       task: タスク
     attributes:
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認用）
       task:
         name: タスク名
         content: 内容

--- a/db/migrate/20201209015010_create_users.rb
+++ b/db/migrate/20201209015010_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false, unique: true, index: true
+      t.string :remember_token
+      t.string :password_digest
+      t.boolean :admin, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201209031050_add_user_ref_to_task.rb
+++ b/db/migrate/20201209031050_add_user_ref_to_task.rb
@@ -1,0 +1,5 @@
+class AddUserRefToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, null: false, default: 1, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_092829) do
+ActiveRecord::Schema.define(version: 2020_12_09_015010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 2020_12_02_092829) do
     t.integer "priority"
     t.index ["name"], name: "index_tasks_on_name"
     t.index ["status"], name: "index_tasks_on_status"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "remember_token"
+    t.string "password_digest"
+    t.boolean "admin", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_015010) do
+ActiveRecord::Schema.define(version: 2020_12_09_031050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,10 @@ ActiveRecord::Schema.define(version: 2020_12_09_015010) do
     t.date "deadline"
     t.integer "status"
     t.integer "priority"
+    t.bigint "user_id", default: 1, null: false
     t.index ["name"], name: "index_tasks_on_name"
     t.index ["status"], name: "index_tasks_on_status"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +40,5 @@ ActiveRecord::Schema.define(version: 2020_12_09_015010) do
     t.index ["email"], name: "index_users_on_email"
   end
 
+  add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+
+User.create!(
+    name: "hayase",
+    email: "kazuki@gmail.com",
+    password: "password",
+    password_confirmation: "password",
+    admin: true
+)

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:deadline, Date.today)
     status { :not_started }
     priority { :middle }
+    user { FactoryBot.create(:user) }
 
     trait :doing do
       status { :doing }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :user do
-    name { "MyString" }
-    email { "MyString" }
-    remember_token { "MyString" }
+    sequence(:name) { |n| "ユーザー#{n}" }
+    sequence(:email) { |n| "user#{n}@test.com" }
+    password { "password" }
+    password_confirmation { "password" }
     admin { false }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { "MyString" }
+    email { "MyString" }
+    remember_token { "MyString" }
+    admin { false }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,103 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validations" do
+    let(:user) {build(:user)}
+
+    subject { user } 
+
+    shared_examples "ユーザーは有効" do
+      it {is_expected.to be_valid}
+    end
+
+    shared_examples "ユーザーは無効" do
+      it {is_expected.to be_invalid}
+    end
+
+    context "全ての要素が有効な時" do
+      it_behaves_like "ユーザーは有効"
+    end
+    
+    context "nameが空の時" do
+      before {user.name = nil}
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "emailが空の時" do
+      before {user.email = nil}
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "passwordが空の時" do
+      let(:user) {build(:user, password: nil, password_confirmation: nil)}
+      it_behaves_like "ユーザーは無効"
+    end
+    
+    context "nameが50文字以下の時" do
+      before {user.name = "a" * 50}
+      it_behaves_like "ユーザーは有効"
+    end
+
+    context "nameが51文字以上の時" do
+      before {user.name = "a" * 51}
+      it_behaves_like "ユーザーは無効"
+    end
+    context "emailが50文字以下の時" do
+      before {user.email = "a" * 41 + "@test.com"}
+      it_behaves_like "ユーザーは有効"
+    end
+
+    context "emailが51文字以上の時" do
+      before {user.email = "a" * 51 + "@test.com"}
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "emailが無効な値の時" do
+      before {user.email = "test.com"}
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "emailが重複してる時" do
+      let(:other_user) { create(:user) } 
+      before {user.email = other_user.email}
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "passwordが5文字以下の時" do
+      before do
+        user.password = "a" * 5
+        user.password_confirmation = "a" * 5
+      end
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "passwordが6文字以上72文字以下の時" do
+      before do
+        user.password = "a" * 6
+        user.password_confirmation = "a" * 6
+      end
+      it_behaves_like "ユーザーは有効"
+    end
+
+    context "passwordが6文字以上72文字以下の時" do
+      before do
+        user.password = "a" * 72
+        user.password_confirmation = "a" * 72
+      end
+      it_behaves_like "ユーザーは有効"
+    end
+
+    context "passwordが73文字以上の時" do
+      before do
+        user.password = "a" * 73
+        user.password_confirmation = "a" * 73
+      end
+      it_behaves_like "ユーザーは無効"
+    end
+
+    context "passwordとpassword_confirmationが一致しない時" do
+      before {user.password_confirmation = "wordpass"}
+      it_behaves_like "ユーザーは無効"
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,87 +17,96 @@ RSpec.describe User, type: :model do
     context "全ての要素が有効な時" do
       it_behaves_like "ユーザーは有効"
     end
+
+    describe "name" do
+      before do
+        user.name = name
+      end
+      
+      context "nameが空の時" do
+        let(:name) { nil } 
+        it_behaves_like "ユーザーは無効"
+      end
+
+      context "nameが50文字以下の時" do
+        let(:name) { "a" * 50 } 
+        it_behaves_like "ユーザーは有効"
+      end
+
+      context "nameが51文字以上の時" do
+        let(:name) { "a" * 51 } 
+        it_behaves_like "ユーザーは無効"
+      end
+    end
     
-    context "nameが空の時" do
-      before {user.name = nil}
-      it_behaves_like "ユーザーは無効"
-    end
+    describe "email" do
+      before do
+        user.email = email
+      end
+      
+      context "emailが空の時" do
+        let(:email) { nil } 
+        it_behaves_like "ユーザーは無効"
+      end
 
-    context "emailが空の時" do
-      before {user.email = nil}
-      it_behaves_like "ユーザーは無効"
-    end
+      context "emailが50文字以下の時" do
+        let(:email) { "a" * 41 + "@test.com" }
+        it_behaves_like "ユーザーは有効"
+      end
 
-    context "passwordが空の時" do
-      let(:user) {build(:user, password: nil, password_confirmation: nil)}
-      it_behaves_like "ユーザーは無効"
+      context "emailが51文字以上の時" do
+        let(:email) { "a" * 51 + "@test.com" }
+        it_behaves_like "ユーザーは無効"
+      end
+
+      context "emailが無効な値の時" do
+        let(:email) { "test.com" }
+        it_behaves_like "ユーザーは無効"
+      end
+
+      context "emailが重複してる時" do
+        let(:other_user) { create(:user) } 
+        let(:email) { other_user.email }
+        it_behaves_like "ユーザーは無効"
+      end
     end
     
-    context "nameが50文字以下の時" do
-      before {user.name = "a" * 50}
-      it_behaves_like "ユーザーは有効"
-    end
-
-    context "nameが51文字以上の時" do
-      before {user.name = "a" * 51}
-      it_behaves_like "ユーザーは無効"
-    end
-    context "emailが50文字以下の時" do
-      before {user.email = "a" * 41 + "@test.com"}
-      it_behaves_like "ユーザーは有効"
-    end
-
-    context "emailが51文字以上の時" do
-      before {user.email = "a" * 51 + "@test.com"}
-      it_behaves_like "ユーザーは無効"
-    end
-
-    context "emailが無効な値の時" do
-      before {user.email = "test.com"}
-      it_behaves_like "ユーザーは無効"
-    end
-
-    context "emailが重複してる時" do
-      let(:other_user) { create(:user) } 
-      before {user.email = other_user.email}
-      it_behaves_like "ユーザーは無効"
-    end
-
-    context "passwordが5文字以下の時" do
+    describe "password" do
       before do
-        user.password = "a" * 5
-        user.password_confirmation = "a" * 5
+        user.password = password
+        user.password_confirmation = password
       end
-      it_behaves_like "ユーザーは無効"
-    end
-
-    context "passwordが6文字以上72文字以下の時" do
-      before do
-        user.password = "a" * 6
-        user.password_confirmation = "a" * 6
+      
+      context "passwordが空の時" do
+        let(:password) { nil } 
+        it_behaves_like "ユーザーは無効"
       end
-      it_behaves_like "ユーザーは有効"
-    end
 
-    context "passwordが6文字以上72文字以下の時" do
-      before do
-        user.password = "a" * 72
-        user.password_confirmation = "a" * 72
+      context "passwordが5文字以下の時" do
+        let(:password) {"a" * 5}
+        it_behaves_like "ユーザーは無効"
       end
-      it_behaves_like "ユーザーは有効"
-    end
 
-    context "passwordが73文字以上の時" do
-      before do
-        user.password = "a" * 73
-        user.password_confirmation = "a" * 73
+      context "passwordが6文字以上72文字以下の時" do
+        let(:password) {"a" * 6}
+        it_behaves_like "ユーザーは有効"
       end
-      it_behaves_like "ユーザーは無効"
-    end
 
-    context "passwordとpassword_confirmationが一致しない時" do
-      before {user.password_confirmation = "wordpass"}
-      it_behaves_like "ユーザーは無効"
+      context "passwordが6文字以上72文字以下の時" do
+        let(:password) {"a" * 72}
+        it_behaves_like "ユーザーは有効"
+      end
+
+      context "passwordが73文字以上の時" do
+        let(:password) {"a" * 73}
+        it_behaves_like "ユーザーは無効"
+      end
+
+      context "passwordとpassword_confirmationが一致しない時" do
+        let(:password) { "password" } 
+        before {user.password_confirmation = "wordpass"}
+        it_behaves_like "ユーザーは無効"
+      end
     end
   end
 end


### PR DESCRIPTION
# カリキュラム
[ステップ21: 複数人で利用できるようにしよう（ユーザの導入）](https://github.com/KazukiHayase/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9721-%E8%A4%87%E6%95%B0%E4%BA%BA%E3%81%A7%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AE%E5%B0%8E%E5%85%A5)

# 処理概要
Userモデルを作成しました。
Taskテーブルに外部キーとインデックスを追加しました。
```has_many,belongs_to```でUserとTaskの関連付けを追加しました。
すでに登録されてるタスクとユーザーが紐づくようにTaskテーブルの外部キーにデフォルト値を設定しました。


# 要件・仕様
- ユーザモデルを作成してみましょう
- 最初のユーザをseedで作成してみましょう
- ユーザとタスクが紐づくようにしましょう
  - 関連に対してインデックスを貼りましょう
  - ※ Herokuにデプロイした際に、すでに登録されているタスクとユーザが紐づいているようにしてください（データメンテナンス）

# 動作確認
テストがパスすることを確認
