### PR TITLE
ステップ24: ユーザにロールを追加しよう

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,7 @@
 //= require popper
 //= require bootstrap-sprockets
 //= require_tree .
+
+$(document).ready(function(){
+    setTimeout("$('.flash').fadeOut(2000)", 1000) 
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -82,6 +82,10 @@ header {
     height: 100px;
     width: 90%;
     margin: 10px auto 0;
+    position: fixed;
+    top: 60px;
+    left: 50%;
+    transform: translateX(-50%);
     text-align: center;
     font-size: 30px;
 }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -40,4 +40,7 @@
     .task_count {
         width: 100px;
     }
+    .role {
+        width: 150px;
+    }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
     before_action :get_user, only: [:show, :edit, :update, :destroy]
+    before_action :admin_user
 
     def index
         @users = User.preload(:tasks)
@@ -51,5 +52,9 @@ class UsersController < ApplicationController
 
     def get_user
         @user = User.find(params[:id])
+    end
+
+    def admin_user
+        raise ApplicationError::NotPermittedError unless current_user.admin?
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
     private
 
     def user_params
-        params.require(:user).permit(:name, :email, :password, :password_confirmation)
+        params.require(:user).permit(:name, :email, :password, :password_confirmation, :admin)
     end
 
     def get_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,9 @@ class User < ApplicationRecord
     # アソシエーション
     has_many :tasks, dependent: :destroy
 
+    # コールバック
+    before_destroy :must_have_at_least_one_admin_user
+
     # その他
     has_secure_password validations: true
     attr_accessor :remember_token
@@ -34,5 +37,9 @@ class User < ApplicationRecord
     def authenticated?(remember_token)
         return false if remember_digest.nil?
         BCrypt::Password.new(remember_token).is_password?(remember_token)
+    end
+
+    def must_have_at_least_one_admin_user
+        throw :abort unless User.where(admin: true).count > 1
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
     # その他
     has_secure_password validations: true
     attr_accessor :remember_token
+    enum admin: {"admin": true, "not_admin": false}
 
     def self.new_token
         SecureRandom.urlsafe_base64

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,19 +3,21 @@
         <li class="logo">TaskTool</li>
         <div class="flex">
             <% if logged_in? %>
-                <li class="nav_item dropdown">
-                    <a type="button" id="dropdown"
-                            class="dropdown-toggle"
-                            data-toggle="dropdown"
-                            aria-haspopup="true"
-                            aria-expanded="false">
-                            管理メニュー
-                    </a>
-                    <div class="dropdown-menu" aria-labelledby="dropdown">
-                        <%= link_to "ユーザー一覧", users_path, class: "dropdown-item" %>
-                        <%= link_to "ユーザー作成", new_user_path, class: "dropdown-item" %>
-                    </div>
-                </li>
+                <% if current_user.admin? %>
+                    <li class="nav_item dropdown">
+                        <a type="button" id="dropdown"
+                                class="dropdown-toggle"
+                                data-toggle="dropdown"
+                                aria-haspopup="true"
+                                aria-expanded="false">
+                                管理メニュー
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="dropdown">
+                            <%= link_to "ユーザー一覧", users_path, class: "dropdown-item" %>
+                            <%= link_to "ユーザー作成", new_user_path, class: "dropdown-item" %>
+                        </div>
+                    </li>
+                <% end %>
                 <li class="nav_item dropdown">
                     <a type="button" id="dropdown2"
                             class="dropdown-toggle"

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -3,6 +3,7 @@
         <div class="name"><%= link_to user.name, user_path(user) %></div>
         <div class="email"><%= user.email %></div>
         <div class="task_count"><%= user.tasks.size %></div>
+        <div class="role"><%= user.admin_i18n %></div>
     </div>
     <div>
         <%= link_to "編集", edit_user_path(user), class: "link_edit" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -11,5 +11,10 @@
         <br>
         <%= f.email_field :email %>
     </div>
+    <div>
+        <%= f.label :admin %>
+        <br>
+        <%= f.select :admin, User.admins_i18n.invert %>
+    </div>
     <%= f.submit "編集" %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,6 +4,7 @@
         <div class="name">ユーザー名</div>
         <div class="email">メールアドレス</div>
         <div class="task_count">タスク数</div>
+        <div class="role">ユーザー種別</div>
     </li>
     <div id="users">
         <%= render @users %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,6 +12,11 @@
         <%= f.email_field :email %>
     </div>
     <div>
+        <%= f.label :admin %>
+        <br>
+        <%= f.select :admin, User.admins_i18n.invert %>
+    </div>
+    <div>
         <%= f.label :password %>
         <br>
         <%= f.password_field :password %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,9 +13,12 @@ require "action_cable/engine"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+require_relative "../lib/exception.rb"
 
 module App
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require "action_cable/engine"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認用）
+        admin: ユーザー種別
       task:
         name: タスク名
         content: 内容
@@ -25,6 +26,10 @@ ja:
         low: "低"
         middle: "中"
         high: "高"
+    user:
+      admin:
+        admin: "管理ユーザー"
+        not_admin: "一般ユーザー"
   views:
     pagination:
       first: "&laquo; 最初"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,5 +12,5 @@ User.create!(
     email: "kazuki@gmail.com",
     password: "password",
     password_confirmation: "password",
-    admin: true
+    admin: "admin"
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,5 +12,5 @@ User.create!(
     email: "kazuki@gmail.com",
     password: "password",
     password_confirmation: "password",
-    admin: "admin"
+    admin: :admin
 )

--- a/lib/exception.rb
+++ b/lib/exception.rb
@@ -1,0 +1,7 @@
+module ApplicationError
+    class NotPermittedError < StandardError
+        def initialize(msg="ページにアクセスする権利がありません")
+            super
+        end
+    end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@test.com" }
     password { "password" }
     password_confirmation { "password" }
-    admin { false }
+    admin { "not_admin" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@test.com" }
     password { "password" }
     password_confirmation { "password" }
-    admin { "not_admin" }
+    admin { :not_admin }
   end
 end


### PR DESCRIPTION
# カリキュラム
[ステップ24: ユーザにロールを追加しよう](https://github.com/KazukiHayase/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9724-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)

# 処理概要
userモデルのadminの真理値で管理ユーザーと一般ユーザーを区別するようにしました。
管理ユーザーだけが管理画面にアクセスできるようにし、
一般ユーザーが管理画面にアクセスした場合に例外を発生させるようにしました。
（例外によるエラーページの表示はstep25で実装）
管理ユーザが1人もいなくならないようにコールバックを登録

# 要件・仕様
- ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
- 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
  - 一般ユーザが管理画面にアクセスした場合、専用の例外を出してみましょう
  - 例外を補足して、適切にエラーページを表示しましょう（ステップ25で実施しても構いません）
- ユーザ管理画面でロールを選択できるようにしましょう
- 管理ユーザが1人もいなくならないように削除の制御をしましょう
  - モデルのコールバックを利用してみましょう
- ※ Gemの使用・不使用は自由です

# 動作確認
ブラウザ上でユーザーのロールを選択できることを確認
![タイトルなし](https://user-images.githubusercontent.com/74339461/102321397-f6187200-3fc0-11eb-866a-39c4869475ba.gif)
管理ユーザー以外が管理ページにアクセスしたときに例外が発生することを確認
![スクリーンショット 2020-12-16 17 08 27](https://user-images.githubusercontent.com/74339461/102321659-560f1880-3fc1-11eb-8752-938f33b6e904.png)
コンソールで管理ユーザーが一人もいなくならないようになっていることを確認
<img width="724" alt="スクリーンショット 2020-12-16 17 00 40" src="https://user-images.githubusercontent.com/74339461/102321545-2e1fb500-3fc1-11eb-8425-8066fd0d0b77.png">

# 質問

> ユーザ管理画面でロールを選択できるようにしましょう

ロールの管理について質問です。今回の実装の方法では```user_params```に```admin```を加えてユーザー作成時、編集時にadminの値を選択するようにしました。strong_parametersに```admin```を加えるのは少しどうかと思ったのですが今回の場合だとユーザーの作成、編集自体が管理ユーザーしかできないので問題ないかなと思ってこの実装方法にこの形で大丈夫でしょうか？